### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -7,6 +7,6 @@
     ],
     "description": "Help for non-conforming standard libraries.",
     "category": [
-        "workarounds"
+        "Workarounds"
     ]
 }


### PR DESCRIPTION
To match the pattern other boost libraries are using, the "category" values are capitalized.